### PR TITLE
IsInfoOnly works with Range fields in Smart Browse

### DIFF
--- a/src/main/client/org/adempiere/controller/SmallViewController.java
+++ b/src/main/client/org/adempiere/controller/SmallViewController.java
@@ -394,6 +394,7 @@ public abstract class SmallViewController implements SmallViewEditable, Vetoable
 			GridFieldVO voBase_To = createVO(field, true, windowNo);
 			GridField gField_To = new GridField(voBase_To);
 			//	
+			fieldsInfoOnly.put(gField_To.getColumnNameAlias(), field.isInfoOnly()); 
 			fieldsTo.add(gField_To);
 		} else {
 			fieldsTo.add (null);


### PR DESCRIPTION
This changes adds the "_To" field generated by a range to be part of isInfoOnly if the original field is IsInfoOnly. This way the smart browse do not use only the "_To" field as a Query Criteria